### PR TITLE
Use patchable package refrences

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,16 @@ edition = "2018"
 [dependencies]
 arrayvec = { version = "0.7.1", default-features = false }
 base64 = { version = "0.13.0", default-features = false }
-nanos_sdk = { git = "https://github.com/LedgerHQ/ledger-nanos-sdk.git" }
-nanos_ui = { git = "https://github.com/LedgerHQ/ledger-nanos-ui.git" }
-ledger-log = { git = "https://github.com/alamgu/ledger-log.git" }
+nanos_sdk = "0.1.0"
+nanos_ui = "0.1.0"
+ledger-log = "0.1.0"
 zeroize = { version = "1.5.2", default-features = false }
 
 
 [features]
 speculos = ["nanos_sdk/speculos"]
+
+[patch.crates-io]
+nanos_sdk = { git = "https://github.com/LedgerHQ/ledger-nanos-sdk.git" }
+nanos_ui = { git = "https://github.com/LedgerHQ/ledger-nanos-ui.git" }
+ledger-log = { git = "https://github.com/alamgu/ledger-log.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger-crypto-helpers"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 [dependencies]
 arrayvec = { version = "0.7.1", default-features = false }
 base64 = { version = "0.13.0", default-features = false }
-nanos_sdk = "0.1.0"
-nanos_ui = "0.1.0"
-ledger-log = "0.1.0"
+nanos_sdk = "*"
+nanos_ui = "*"
+ledger-log = "*"
 zeroize = { version = "1.5.2", default-features = false }
 
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,8 +4,14 @@
 
 Breaking change.
 
-Rework as the unstable `?` features change.
+- Rework as the unstable `?` features change.
+
+- Add `try_option` function.
+
+- Use new SDK, dropping a bunch of internals in the process.
+
+- Compress EDDSA public keys in `with_public_keys`.
 
 ## 0.1.0 Initial release for Rust 1.53
 
-We are just capping off the current development state before making breaking changes due to the evoluation of unstable Rust features past 0.53.
+We are just capping off the current development state before making breaking changes due to the evolution of unstable Rust features past 0.53.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+Breaking change.
+
+Rework as the unstable `?` features change.
+
 ## 0.1.0 Initial release for Rust 0.53
 
 We are just capping off the current development state before making breaking changes due to the evoluation of unstable Rust features past 0.53.

--- a/src/common.rs
+++ b/src/common.rs
@@ -13,7 +13,7 @@ pub fn with_public_keys<V, A:Address<A>>(
     let mut pubkey = Default::default();
     with_private_key(path, |ec_k| {
         info!("Getting private key");
-        get_pubkey_from_privkey(ec_k, &mut pubkey).ok()?;
+        get_pubkey_from_privkey(ec_k, &mut pubkey)?;
         Ok(())
     })?;
     let pkh = <A as Address<A>>::get_address(&pubkey)?;

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,6 +6,10 @@ use nanos_sdk::io::SyscallError;
 
 use crate::internal::*;
 
+pub fn try_option<A>(q: Option<A>) -> Result<A, CryptographyError> {
+    q.ok_or(CryptographyError::NoneError)
+}
+
 pub fn with_public_keys<V, A:Address<A>>(
   path: &[u32],
   f: impl FnOnce(&nanos_sdk::bindings::cx_ecfp_public_key_t, &A) -> Result<V, CryptographyError>

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,83 +1,37 @@
-use core::default::Default;
 use core::fmt;
-use ledger_log::*;
 use nanos_sdk::bindings::*;
+use nanos_sdk::ecc::*;
+use arrayvec::{CapacityError};
 use nanos_sdk::io::SyscallError;
-
-use crate::internal::*;
 
 pub fn try_option<A>(q: Option<A>) -> Result<A, CryptographyError> {
     q.ok_or(CryptographyError::NoneError)
 }
 
-pub fn with_public_keys<V, A:Address<A>>(
-  path: &[u32],
-  f: impl FnOnce(&nanos_sdk::bindings::cx_ecfp_public_key_t, &A) -> Result<V, CryptographyError>
-) -> Result<V, CryptographyError> {
-    let mut pubkey = Default::default();
-    with_private_key(path, |ec_k| {
-        info!("Getting private key");
-        get_pubkey_from_privkey(ec_k, &mut pubkey)?;
-        Ok(())
-    })?;
-    let pkh = <A as Address<A>>::get_address(&pubkey)?;
-    f(&pubkey, &pkh)
-}
-
-pub fn public_key_bytes(key: &nanos_sdk::bindings::cx_ecfp_public_key_t) -> &[u8] {
-    &key.W[1..33]
-}
-
 // Target chain's notion of an address and how to format one.
 
-pub trait Address<A>: fmt::Display {
-    fn get_address(key: &nanos_sdk::bindings::cx_ecfp_public_key_t) -> Result<A, SyscallError>;
+pub trait Address<A, K>: fmt::Display {
+    fn get_address(key: &K) -> Result<A, SyscallError>;
+    fn get_binary_address(&self) -> &[u8];
 }
 
-pub struct PKH(pub [u8; 20]);
+pub struct PubKey<const N: usize, const T: char>(nanos_sdk::ecc::ECPublicKey<N, T>);
 
-impl Address<PKH> for PKH {
-    fn get_address(key: &nanos_sdk::bindings::cx_ecfp_public_key_t) -> Result<Self, SyscallError> {
-        let mut public_key_hash = [0; 32];
-        let key_bytes = public_key_bytes(key);
-        unsafe {
-            let _len: size_t = cx_hash_sha256(
-                key_bytes.as_ptr(),
-                key_bytes.len() as u32,
-                public_key_hash.as_mut_ptr(),
-                public_key_hash.len() as u32,
-            );
-        }
-        let mut rv=PKH([0; 20]);
-        rv.0.clone_from_slice(&public_key_hash[0..20]);
-        Ok(rv)
+impl<const N: usize, const T: char> Address<PubKey<N, T>, nanos_sdk::ecc::ECPublicKey<N, T>> for PubKey<N, T> {
+    fn get_address(key: &nanos_sdk::ecc::ECPublicKey<N, T>) -> Result<Self, SyscallError> {
+        Ok(PubKey(key.clone()))
+    }
+    fn get_binary_address(&self) -> &[u8] {
+        &self.0.pubkey
     }
 }
-
-impl fmt::Display for PKH {
+impl<const N: usize, const T: char> fmt::Display for PubKey<N, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "")?;
-        for byte in self.0 {
-            write!(f, "{:02x}", byte)?;
-        }
-        Ok(())
+        write!(f, "{}", HexSlice(&self.0.pubkey[1..self.0.keylength]))
     }
 }
 
-pub struct PubKey(cx_ecfp_public_key_t);
-
-impl Address<PubKey> for PubKey {
-    fn get_address(key: &nanos_sdk::bindings::cx_ecfp_public_key_t) -> Result<Self, SyscallError> {
-        Ok(PubKey(*key))
-    }
-}
-impl fmt::Display for PubKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", HexSlice(&self.0.W[1..self.0.W_len as usize]))
-    }
-}
-
-struct HexSlice<'a>(&'a [u8]);
+pub struct HexSlice<'a>(pub &'a [u8]);
 
 // You can choose to implement multiple traits, like Lower and UpperHex
 impl fmt::Display for HexSlice<'_> {
@@ -96,4 +50,28 @@ extern "C" {
       r: *mut *const u8, r_len: *mut size_t,
       s: *mut *const u8, s_len: *mut size_t,
       ) -> u32;
+}
+
+#[derive(Debug)]
+pub enum CryptographyError {
+  NoneError,
+  SyscallError(SyscallError),
+  CxError(CxError),
+  CapacityError(CapacityError)
+}
+
+impl From<SyscallError> for CryptographyError {
+    fn from(e: SyscallError) -> Self {
+        CryptographyError::SyscallError(e)
+    }
+}
+impl From<CxError> for CryptographyError {
+    fn from(e: CxError) -> Self {
+        CryptographyError::CxError(e)
+    }
+}
+impl From<CapacityError> for CryptographyError {
+    fn from(e: CapacityError) -> Self {
+        CryptographyError::CapacityError(e)
+    }
 }

--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -7,6 +7,7 @@ use zeroize::{Zeroizing};
 
 use crate::common::*;
 use crate::hasher::*;
+use crate::eddsa::{Ed25519PublicKey, Ed25519RawPubKeyAddress, ed25519_public_key_bytes, with_public_keys};
 
 struct BnLock;
 
@@ -133,13 +134,11 @@ impl Ed25519 {
 
         let path_tmp = self.path.clone();
             trace!("ping");
-        with_private_key(&path_tmp, |privkey| {
-            let key = privkey.public_key()?;
+        with_public_keys::<_, CryptographyError, _, _>(&path_tmp, |key: &Ed25519PublicKey, _: &Ed25519RawPubKeyAddress| {
             // Note: public key has a byte in front of it in W, from how the ledger's system call
             // works; it's not for ed25519.
             trace!("ping");
-            self.hash.update(&key.pubkey[1..key.keylength as usize]);
-            trace!("ping");
+            self.hash.update(ed25519_public_key_bytes(key));
             Ok(())
         })?;
         Ok(())

--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -64,7 +64,7 @@ impl Ed25519 {
             self.hash.clear();
             self.hash.update(&temp.0[32..64]);
             Ok(())
-        }).ok()?;
+        })?;
 
         self.path = path.clone();
 
@@ -85,28 +85,28 @@ impl Ed25519 {
             let _lock = BnLock::lock();
             trace!("done_with_r lock");
             let mut r = CX_BN_FLAG_UNSET;
-            // call_c_api_function!( cx_bn_lock(32,0) ).ok()?;
+            // call_c_api_function!( cx_bn_lock(32,0) )?;
             trace!("ping");
             self.r_pre = self.hash.finalize();
             self.r_pre.0.reverse();
 
             // Make r_pre into a BN
-            call_c_api_function!( cx_bn_alloc_init(&mut r as *mut cx_bn_t, 64, self.r_pre.0.as_ptr(), self.r_pre.0.len() as u32) ).ok()?;
+            call_c_api_function!( cx_bn_alloc_init(&mut r as *mut cx_bn_t, 64, self.r_pre.0.as_ptr(), self.r_pre.0.len() as u32) )?;
             trace!("ping");
 
             let mut ed_p = cx_ecpoint_t::default();
             // Get the generator for Ed25519's curve
-            call_c_api_function!( cx_ecpoint_alloc(&mut ed_p as *mut cx_ecpoint_t, CX_CURVE_Ed25519) ).ok()?;
+            call_c_api_function!( cx_ecpoint_alloc(&mut ed_p as *mut cx_ecpoint_t, CX_CURVE_Ed25519) )?;
             trace!("ping");
-            call_c_api_function!( cx_ecdomain_generator_bn(CX_CURVE_Ed25519, &mut ed_p) ).ok()?;
+            call_c_api_function!( cx_ecdomain_generator_bn(CX_CURVE_Ed25519, &mut ed_p) )?;
             trace!("ping");
 
             // Multiply r by generator, store in ed_p
-            call_c_api_function!( cx_ecpoint_scalarmul_bn(&mut ed_p, r) ).ok()?;
+            call_c_api_function!( cx_ecpoint_scalarmul_bn(&mut ed_p, r) )?;
             trace!("ping");
 
             // and copy/compress it to self.r
-            call_c_api_function!( cx_ecpoint_compress(&ed_p, self.r.as_mut_ptr(), self.r.len() as u32, &mut sign) ).ok()?;
+            call_c_api_function!( cx_ecpoint_compress(&ed_p, self.r.as_mut_ptr(), self.r.len() as u32, &mut sign) )?;
             trace!("ping");
         }
 
@@ -134,7 +134,7 @@ impl Ed25519 {
             self.hash.update(&key.W[1..key.W_len as usize]);
             trace!("ping");
             Ok(())
-        }).ok()?;
+        })?;
         Ok(())
     }
 
@@ -157,12 +157,12 @@ impl Ed25519 {
 
             // Make k into a BN
             let mut h_scalar_bn = CX_BN_FLAG_UNSET;
-            call_c_api_function!( cx_bn_alloc_init(&mut h_scalar_bn as *mut cx_bn_t, 64, h_scalar.0.as_ptr(), h_scalar.0.len() as u32) ).ok()?;
+            call_c_api_function!( cx_bn_alloc_init(&mut h_scalar_bn as *mut cx_bn_t, 64, h_scalar.0.as_ptr(), h_scalar.0.len() as u32) )?;
 
             // Get the group order
             let mut ed25519_order = CX_BN_FLAG_UNSET;
-            call_c_api_function!( cx_bn_alloc(&mut ed25519_order, 64) ).ok()?;
-            call_c_api_function!( cx_ecdomain_parameter_bn( CX_CURVE_Ed25519, CX_CURVE_PARAM_Order, ed25519_order) ).ok()?;
+            call_c_api_function!( cx_bn_alloc(&mut ed25519_order, 64) )?;
+            call_c_api_function!( cx_ecdomain_parameter_bn( CX_CURVE_Ed25519, CX_CURVE_PARAM_Order, ed25519_order) )?;
 
             // Generate the hashed private key
             let mut rv = CX_BN_FLAG_UNSET;
@@ -181,32 +181,32 @@ impl Ed25519 {
             let mut key_bn = CX_BN_FLAG_UNSET;
 
             // Load key into bn
-            call_c_api_function!( cx_bn_alloc_init(&mut key_bn as *mut cx_bn_t, 64, key_slice.as_ptr(), key_slice.len() as u32) ).ok()?;
+            call_c_api_function!( cx_bn_alloc_init(&mut key_bn as *mut cx_bn_t, 64, key_slice.as_ptr(), key_slice.len() as u32) )?;
             hash_ref.clear();
 
-            call_c_api_function!( cx_bn_alloc(&mut rv, 64) ).ok()?;
+            call_c_api_function!( cx_bn_alloc(&mut rv, 64) )?;
 
             // multiply h_scalar_bn by key_bn
-            call_c_api_function!( cx_bn_mod_mul(rv, key_bn, h_scalar_bn, ed25519_order) ).ok()?;
+            call_c_api_function!( cx_bn_mod_mul(rv, key_bn, h_scalar_bn, ed25519_order) )?;
 
             // Destroy the private key, so it doesn't leak from with_private_key even in the bn
             // area. temp will zeroize on drop already.
-            call_c_api_function!( cx_bn_destroy(&mut key_bn) ).ok()?;
+            call_c_api_function!( cx_bn_destroy(&mut key_bn) )?;
             Ok((rv, _lock, ed25519_order))
         })?;
 
         // Reload the r value into the bn area
         let mut r = CX_BN_FLAG_UNSET;
-        call_c_api_function!( cx_bn_alloc_init(&mut r as *mut cx_bn_t, 64, self.r_pre.0.as_ptr(), self.r_pre.0.len() as u32)).ok()?;
+        call_c_api_function!( cx_bn_alloc_init(&mut r as *mut cx_bn_t, 64, self.r_pre.0.as_ptr(), self.r_pre.0.len() as u32))?;
 
         // finally, compute s:
         let mut s = CX_BN_FLAG_UNSET;
-        call_c_api_function!( cx_bn_alloc(&mut s, 64) ).ok()?;
-        call_c_api_function!( cx_bn_mod_add(s, h_a, r, ed25519_order)).ok()?;
+        call_c_api_function!( cx_bn_alloc(&mut s, 64) )?;
+        call_c_api_function!( cx_bn_mod_add(s, h_a, r, ed25519_order))?;
 
         // and copy s back to normal memory to return.
         let mut s_bytes = [0; 32];
-        call_c_api_function!(cx_bn_export(s, s_bytes.as_mut_ptr(), s_bytes.len() as u32)).ok()?;
+        call_c_api_function!(cx_bn_export(s, s_bytes.as_mut_ptr(), s_bytes.len() as u32))?;
 
         s_bytes.reverse();
 

--- a/src/eddsa.rs
+++ b/src/eddsa.rs
@@ -4,7 +4,6 @@ use nanos_sdk::io::SyscallError;
 use nanos_sdk::bindings::*;
 
 use crate::common::*;
-use crate::internal::*;
 
 #[derive(Clone,Debug,PartialEq)]
 pub struct EdDSASignature(pub [u8; 64]);

--- a/src/eddsa.rs
+++ b/src/eddsa.rs
@@ -19,11 +19,12 @@ pub fn eddsa_sign(
     Ok(EdDSASignature(sig.0))
 }
 
-pub fn with_public_keys<V, E, A:Address<A, Ed25519PublicKey>>(
+pub fn with_public_keys<V, E, A:Address<A, Ed25519PublicKey>, F>(
   path: &[u32],
-  f: impl FnOnce(&nanos_sdk::ecc::ECPublicKey<65, 'E'>, &A) -> Result<V, E>
+  f: F,
 ) -> Result<V, E>
-  where E: From<CryptographyError>
+  where E: From<CryptographyError>,
+        F: FnOnce(&nanos_sdk::ecc::ECPublicKey<65, 'E'>, &A) -> Result<V, E>
 {
     let mut pubkey = Ed25519::from_bip32(path).public_key().map_err(Into::<CryptographyError>::into)?;
     call_c_api_function!(cx_edwards_compress_point_no_throw(CX_CURVE_Ed25519, pubkey.pubkey.as_mut_ptr(), pubkey.keylength as u32)).map_err(Into::<CryptographyError>::into)?;

--- a/src/eddsa.rs
+++ b/src/eddsa.rs
@@ -10,7 +10,7 @@ pub struct EdDSASignature(pub [u8; 64]);
 pub fn eddsa_sign(
     path : &ArrayVec<u32, 10>,
     m: &[u8],
-) -> Option<EdDSASignature> {
+) -> Result<EdDSASignature, CryptographyError> {
     let mut sig:[u8;64]=[0; 64];
     with_private_key(path, |key| {
         call_c_api_function!(
@@ -21,8 +21,8 @@ pub fn eddsa_sign(
                 m.len() as u32,
                 sig.as_mut_ptr(),
                 sig.len() as u32)
-        ).ok()?;
+        )?;
         Ok(())
-    }).ok()?;
-    Some(EdDSASignature(sig))
+    })?;
+    Ok(EdDSASignature(sig))
 }

--- a/src/eddsa.rs
+++ b/src/eddsa.rs
@@ -1,28 +1,47 @@
 use arrayvec::{ArrayVec};
-use nanos_sdk::bindings::*;
+use nanos_sdk::ecc::*;
 use nanos_sdk::io::SyscallError;
 
-use crate::internal::*;
+use crate::common::*;
 
 #[derive(Clone,Debug,PartialEq)]
 pub struct EdDSASignature(pub [u8; 64]);
+
+pub type Ed25519PublicKey = ECPublicKey<65, 'E'>;
 
 pub fn eddsa_sign(
     path : &ArrayVec<u32, 10>,
     m: &[u8],
 ) -> Result<EdDSASignature, CryptographyError> {
-    let mut sig:[u8;64]=[0; 64];
-    with_private_key(path, |key| {
-        call_c_api_function!(
-            cx_eddsa_sign_no_throw(
-                key,
-                CX_SHA512,
-                m.as_ptr(),
-                m.len() as u32,
-                sig.as_mut_ptr(),
-                sig.len() as u32)
-        )?;
-        Ok(())
-    })?;
-    Ok(EdDSASignature(sig))
+    let sig = Ed25519::from_bip32(path).sign(m)?;
+    Ok(EdDSASignature(sig.0))
+}
+
+pub fn with_public_keys<V, A:Address<A, Ed25519PublicKey>>(
+  path: &[u32],
+  f: impl FnOnce(&nanos_sdk::ecc::ECPublicKey<65, 'E'>, &A) -> Result<V, CryptographyError>
+) -> Result<V, CryptographyError> {
+    let pubkey = Ed25519::from_bip32(path).public_key()?;
+    let pkh = <A as Address<A, Ed25519PublicKey>>::get_address(&pubkey)?;
+    f(&pubkey, &pkh)
+}
+
+pub struct Ed25519RawPubKeyAddress(nanos_sdk::ecc::ECPublicKey<65, 'E'>);
+
+impl Address<Ed25519RawPubKeyAddress, nanos_sdk::ecc::ECPublicKey<65, 'E'>> for Ed25519RawPubKeyAddress {
+    fn get_address(key: &nanos_sdk::ecc::ECPublicKey<65, 'E'>) -> Result<Self, SyscallError> {
+        Ok(Ed25519RawPubKeyAddress(key.clone()))
+    }
+    fn get_binary_address(&self) -> &[u8] {
+        ed25519_public_key_bytes(&self.0)
+    }
+}
+impl core::fmt::Display for Ed25519RawPubKeyAddress {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", HexSlice(&self.0.pubkey[1..self.0.keylength]))
+    }
+}
+
+pub fn ed25519_public_key_bytes(key: &Ed25519PublicKey) -> &[u8] {
+    &key.pubkey[1..33]
 }

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -18,7 +18,12 @@ pub struct Hash<const N: usize>(pub [u8; N]);
 
 impl <const N: usize> fmt::Display for Hash<N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", base64::display::Base64Display::with_config(&self.0, base64::URL_SAFE_NO_PAD))
+        // Select a sufficiently large buf size for handling hashes of upto 64 bytes
+        const OUT_BUF_SIZE: usize = (66/3)*4;
+        let mut buf: [u8; OUT_BUF_SIZE] = [0; OUT_BUF_SIZE];
+        let bytes_written = base64::encode_config_slice(self.0, base64::URL_SAFE_NO_PAD, &mut buf);
+        let str = core::str::from_utf8(&buf[0..bytes_written]).or(Err(core::fmt::Error))?;
+        write!(f, "{}", str)
     }
 }
 

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -18,7 +18,7 @@ pub struct Hash<const N: usize>(pub [u8; N]);
 
 impl <const N: usize> fmt::Display for Hash<N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Select a sufficiently large buf size for handling hashes of upto 64 bytes
+        // Select a sufficiently large buf size for handling hashes of up to 64 bytes
         const OUT_BUF_SIZE: usize = (66/3)*4;
         let mut buf: [u8; OUT_BUF_SIZE] = [0; OUT_BUF_SIZE];
         let bytes_written = base64::encode_config_slice(self.0, base64::URL_SAFE_NO_PAD, &mut buf);

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -24,7 +24,7 @@ impl<const N: usize> Hash<N> for [u8; N] {
     fn as_mut_ptr(&mut self) -> *mut u8 { (self as &mut [u8]).as_mut_ptr() }
 }
 
-impl<const N: usize, H: Hash<N> + zeroize::DefaultIsZeroes> Hash<N> for Zeroizing<H> {
+impl<const N: usize, H: Hash<N> + zeroize::Zeroize> Hash<N> for Zeroizing<H> {
     fn new(v: [u8; N]) -> Self { Zeroizing::new(H::new(v)) }
     fn as_mut_ptr(&mut self) -> *mut u8 { self.deref_mut().as_mut_ptr() }
 }

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -6,10 +6,11 @@ use arrayvec::{ArrayVec};
 use nanos_sdk::bindings::*;
 use zeroize::{Zeroize, Zeroizing};
 
-pub trait Hasher<const N: usize> {
+pub trait Hasher {
+    const N: usize;
     fn new() -> Self;
     fn update(&mut self, bytes: &[u8]);
-    fn finalize<H: Hash<N>>(&mut self) -> H;
+    fn finalize<H: Hash<{ Self::N }>>(&mut self) -> H;
     fn clear(&mut self);
 }
 
@@ -99,7 +100,8 @@ impl Write for Blake2b {
 #[derive(Clone, Copy)]
 pub struct SHA256(cx_sha256_s);
 
-impl Hasher<32> for SHA256 {
+impl Hasher for SHA256 {
+    const N: usize = 32;
     fn new() -> Self {
         let mut rv = cx_sha256_s::default();
         unsafe { cx_sha256_init_no_throw(&mut rv) };
@@ -135,7 +137,8 @@ impl Hasher<32> for SHA256 {
 #[derive(Clone, Copy)]
 pub struct SHA512(cx_sha512_s);
 
-impl Hasher<64> for SHA512 {
+impl Hasher for SHA512 {
+    const N: usize = 64;
     fn new() -> SHA512 {
         let mut rv = cx_sha512_s::default();
         unsafe { cx_sha512_init_no_throw(&mut rv) };
@@ -171,7 +174,8 @@ impl Hasher<64> for SHA512 {
 #[derive(Clone, Copy)]
 pub struct Blake2b(cx_blake2b_s);
 
-impl Hasher<32> for Blake2b {
+impl Hasher for Blake2b {
+    const N: usize = 32;
     fn new() -> Self {
         let mut rv = cx_blake2b_s::default();
         unsafe { cx_blake2b_init_no_throw(&mut rv, 256) };

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -47,7 +47,15 @@ impl <const N: usize> fmt::Display for HexHash<N> {
     }
 }
 
-impl <const N: usize> Zeroize for HexHash<N> {
+impl<const N: usize> Default for HexHash<N> {
+    fn default() -> Self {
+        Self([Default::default(); N])
+    }
+}
+// Skip because Zeroize impl below is more safe re stack usage
+//impl<const N: usize> zeroize::DefaultIsZeroes for HexHash<N> { }
+
+impl<const N: usize> Zeroize for HexHash<N> {
     fn zeroize(&mut self) { self.0.zeroize(); }
 }
 
@@ -77,6 +85,14 @@ impl <const N: usize> fmt::Display for Base64Hash<N> where [(); Self::BUF_SIZE]:
         write!(f, "{}", str)
     }
 }
+
+impl<const N: usize> Default for Base64Hash<N> {
+    fn default() -> Self {
+        Self([Default::default(); N])
+    }
+}
+// Skip because Zeroize impl below is more safe re stack usage
+//impl<const N: usize> zeroize::DefaultIsZeroes for HexHash<N> { }
 
 impl <const N: usize> Zeroize for Base64Hash<N> {
     fn zeroize(&mut self) { self.0.zeroize(); }

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -61,10 +61,9 @@ impl<const N: usize> Zeroize for HexHash<N> {
 
 pub struct Base64Hash<const N: usize>(pub [u8; N]);
 
-trait HasBufSize<const N: usize> {
+impl<const N: usize> Base64Hash<N> {
     const BUF_SIZE: usize = (N/3)*4+4;
 }
-impl<const N: usize> HasBufSize<N> for Base64Hash<N> { }
 
 impl<const N: usize> Hash<N> for Base64Hash<N> {
     fn new(v: [u8; N]) -> Self {

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -21,7 +21,7 @@ pub trait Hash<const N: usize> {
 
 impl<const N: usize> Hash<N> for [u8; N] {
     fn new(v: [u8; N]) -> Self { v }
-    fn as_mut_ptr(&mut self) -> *mut u8 { self.as_mut_ptr() }
+    fn as_mut_ptr(&mut self) -> *mut u8 { (self as &mut [u8]).as_mut_ptr() }
 }
 
 impl<const N: usize, H: Hash<N> + zeroize::DefaultIsZeroes> Hash<N> for Zeroizing<H> {

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -98,21 +98,6 @@ impl <const N: usize> Zeroize for Base64Hash<N> {
     fn zeroize(&mut self) { self.0.zeroize(); }
 }
 
-impl Write for Blake2b {
-    fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        // Using s directly causes segfault on qemu, so we copy.
-        // Issue #5 is getting to the bottom of this and avoiding this workaround.
-        let mut buffer: ArrayVec<u8, 256> = ArrayVec::new();
-        match buffer.try_extend_from_slice(s.as_bytes()) {
-            Ok(()) => {
-                self.update(buffer.as_slice());
-                Ok(())
-            }
-            _ => { Err(core::fmt::Error) }
-        }
-    }
-}
-
 #[derive(Clone, Copy)]
 pub struct SHA256(cx_sha256_s);
 
@@ -221,5 +206,20 @@ impl Hasher for Blake2b {
             )
         };
         rv
+    }
+}
+
+impl Write for Blake2b {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        // Using s directly causes segfault on qemu, so we copy.
+        // Issue #5 is getting to the bottom of this and avoiding this workaround.
+        let mut buffer: ArrayVec<u8, 256> = ArrayVec::new();
+        match buffer.try_extend_from_slice(s.as_bytes()) {
+            Ok(()) => {
+                self.update(buffer.as_slice());
+                Ok(())
+            }
+            _ => { Err(core::fmt::Error) }
+        }
     }
 }

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -28,7 +28,8 @@ impl <const N: usize> Zeroize for Hash<N> {
 
 impl Write for Blake2b {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        // Using s directly causes segfault on qemu
+        // Using s directly causes segfault on qemu, so we copy.
+        // Issue #5 is getting to the bottom of this and avoiding this workaround.
         let mut buffer: ArrayVec<u8, 256> = ArrayVec::new();
         match buffer.try_extend_from_slice(s.as_bytes()) {
             Ok(()) => {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,6 +1,5 @@
 use arrayvec::{CapacityError};
 use core::default::Default;
-use core::option::NoneError;
 use core::ops::{Deref,DerefMut};
 use ledger_log::*;
 use nanos_sdk::bindings::*;
@@ -88,11 +87,6 @@ impl From<CapacityError> for CryptographyError {
         CryptographyError::CapacityError(e)
     }
 }
-impl From<NoneError> for CryptographyError {
-    fn from(_: NoneError) -> Self {
-        CryptographyError::NoneError
-    }
-}
 
 // #[inline(always)]
 pub fn with_private_key<A>(
@@ -108,7 +102,7 @@ pub fn with_private_key<A>(
             raw_key.as_ptr(),
             32, // raw_key is 64 bytes because of system call weirdness, but we only want 32.
             (&mut ec_k).deref_mut().deref_mut() as *mut nanos_sdk::bindings::cx_ecfp_private_key_t
-        )).ok()?;
+        ))?;
     info!("Key generated");
     f(ec_k.deref_mut().deref_mut())
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,30 +1,11 @@
-use arrayvec::{CapacityError};
+/*use arrayvec::{CapacityError};
 use core::default::Default;
 use core::ops::{Deref,DerefMut};
 use ledger_log::*;
 use nanos_sdk::bindings::*;
 use nanos_sdk::io::SyscallError;
 use zeroize::{DefaultIsZeroes, Zeroizing};
-
-/// Helper function that derives the seed over Ed25519
-pub fn bip32_derive_eddsa(path: &[u32]) -> Result<[u8; 64], SyscallError> {
-    // Note: os_perso_derive_node_bip32 appears to write 64 bytes for CX_CURVE_Ed25519, despite the
-    // private key for ed25519 being only 32 bytes. We still need to give it the space to write to,
-    // of course.
-    let mut raw_key = [0u8; 64];
-    trace!("Calling os_perso_derive_node_bip32 with path {:?}", path);
-    unsafe {
-        os_perso_derive_node_bip32(
-            CX_CURVE_Ed25519,
-            path.as_ptr(),
-            path.len() as u32,
-            raw_key.as_mut_ptr(),
-            core::ptr::null_mut()
-        )
-    };
-    trace!("Success");
-    Ok(raw_key)
-}
+*/
 
 macro_rules! call_c_api_function {
     ($($call:tt)*) => {
@@ -42,67 +23,3 @@ macro_rules! call_c_api_function {
     }
 }
 
-#[inline(always)]
-pub fn get_pubkey_from_privkey(ec_k: &mut nanos_sdk::bindings::cx_ecfp_private_key_t, pubkey: &mut nanos_sdk::bindings::cx_ecfp_public_key_t) -> Result<(), SyscallError> {
-    info!("Calling generate_pair_no_throw");
-    call_c_api_function!(cx_ecfp_generate_pair_no_throw(CX_CURVE_Ed25519, pubkey, ec_k, true))?;
-    info!("Calling compress_point_no_throw");
-    call_c_api_function!(cx_edwards_compress_point_no_throw(CX_CURVE_Ed25519, pubkey.W.as_mut_ptr(), pubkey.W_len))?;
-    pubkey.W_len = 33;
-    Ok(())
-}
-
-#[derive(Default,Copy,Clone)]
-// Would like to use ZeroizeOnDrop here, but the zeroize_derive crate doesn't build. We also would
-// need Zeroize on cx_ecfp_private_key_t instead of using DefaultIsZeroes; we can't implement both
-// Drop and Copy.
-struct PrivateKey(nanos_sdk::bindings::cx_ecfp_private_key_t);
-impl DefaultIsZeroes for PrivateKey {}
-impl Deref for PrivateKey {
-  type Target = nanos_sdk::bindings::cx_ecfp_private_key_t;
-  fn deref(&self) -> &Self::Target {
-      &self.0
-  }
-}
-impl DerefMut for PrivateKey {
-  fn deref_mut(&mut self) -> &mut Self::Target {
-      &mut self.0
-  }
-}
-
-#[derive(Debug)]
-pub enum CryptographyError {
-  NoneError,
-  SyscallError(SyscallError),
-  CapacityError(CapacityError)
-}
-
-impl From<SyscallError> for CryptographyError {
-    fn from(e: SyscallError) -> Self {
-        CryptographyError::SyscallError(e)
-    }
-}
-impl From<CapacityError> for CryptographyError {
-    fn from(e: CapacityError) -> Self {
-        CryptographyError::CapacityError(e)
-    }
-}
-
-// #[inline(always)]
-pub fn with_private_key<A>(
-    path: &[u32],
-    f: impl FnOnce(&mut nanos_sdk::bindings::cx_ecfp_private_key_t) -> Result<A, CryptographyError>
-) -> Result<A, CryptographyError> {
-    info!("Deriving path");
-    let raw_key = bip32_derive_eddsa(path)?;
-    let mut ec_k : Zeroizing<PrivateKey> = Default::default();
-    info!("Generating key");
-    call_c_api_function!(cx_ecfp_init_private_key_no_throw(
-            CX_CURVE_Ed25519,
-            raw_key.as_ptr(),
-            32, // raw_key is 64 bytes because of system call weirdness, but we only want 32.
-            (&mut ec_k).deref_mut().deref_mut() as *mut nanos_sdk::bindings::cx_ecfp_private_key_t
-        ))?;
-    info!("Key generated");
-    f(ec_k.deref_mut().deref_mut())
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![feature(generic_const_exprs)]
 
 pub mod common;
 pub mod hasher;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(try_trait)]
 
 pub mod common;
 pub mod hasher;


### PR DESCRIPTION
This should make it so that dependents can patch this package's dependencies. It also specifies on what version's this package depends on.