### PR TITLE
update Ledger Rust SDK deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,19 @@ version = "0.2.1"
 edition = "2018"
 
 [dev-dependencies]
-ledger_device_sdk = { version = "1.4.3", features = [ "speculos" ] }
-testmacro = { git = "https://github.com/yhql/testmacro"}
+ledger_device_sdk = { version = "1.28.0", features = [ "sys", "speculos" ] }
+testmacro = { git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git" }
 hex-literal = "0.3"
 
 [dependencies]
 arrayvec = { version = "0.7.1", default-features = false }
 base64 = { version = "0.13.0", default-features = false }
 ledger-log = { git = "https://github.com/alamgu/ledger-log.git" }
-ledger_device_sdk = "1.4.3"
-ledger_secure_sdk_sys = "1.1.0"
+ledger_device_sdk = { version = "1.28.0", features = ["sys"] }
 zeroize = { version = "1.5.2", default-features = false }
+
+[patch.crates-io]
+ledger_device_sdk = { git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git" }
+
+[patch."https://github.com/alamgu/ledger-log"]
+ledger-log = { path = "../../alamgu/ledger-log" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ hex-literal = "0.3"
 [dependencies]
 arrayvec = { version = "0.7.1", default-features = false }
 base64 = { version = "0.13.0", default-features = false }
-ledger-log = { git = "https://github.com/alamgu/ledger-log.git", branch = "y333/rust_sdk_single_crate" }
+ledger-log = { git = "https://github.com/alamgu/ledger-log.git" }
 ledger_device_sdk = { version = "1.29.0", features = ["sys"] }
 zeroize = { version = "1.5.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,9 @@ hex-literal = "0.3"
 [dependencies]
 arrayvec = { version = "0.7.1", default-features = false }
 base64 = { version = "0.13.0", default-features = false }
-ledger-log = { git = "https://github.com/alamgu/ledger-log.git" }
+ledger-log = { git = "https://github.com/alamgu/ledger-log.git", branch = "y333/rust_sdk_single_crate" }
 ledger_device_sdk = { version = "1.28.0", features = ["sys"] }
 zeroize = { version = "1.5.2", default-features = false }
 
 [patch.crates-io]
 ledger_device_sdk = { git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git" }
-
-[patch."https://github.com/alamgu/ledger-log"]
-ledger-log = { path = "../../alamgu/ledger-log" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.1"
 edition = "2018"
 
 [dev-dependencies]
-ledger_device_sdk = { version = "1.28.0", features = [ "sys", "speculos" ] }
+ledger_device_sdk = { version = "1.29.0", features = [ "sys", "speculos" ] }
 testmacro = { git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git" }
 hex-literal = "0.3"
 
@@ -12,8 +12,5 @@ hex-literal = "0.3"
 arrayvec = { version = "0.7.1", default-features = false }
 base64 = { version = "0.13.0", default-features = false }
 ledger-log = { git = "https://github.com/alamgu/ledger-log.git", branch = "y333/rust_sdk_single_crate" }
-ledger_device_sdk = { version = "1.28.0", features = ["sys"] }
+ledger_device_sdk = { version = "1.29.0", features = ["sys"] }
 zeroize = { version = "1.5.2", default-features = false }
-
-[patch.crates-io]
-ledger_device_sdk = { git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git" }

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,7 +2,7 @@ use arrayvec::CapacityError;
 use core::fmt;
 use ledger_device_sdk::ecc::*;
 use ledger_device_sdk::io::SyscallError;
-use ledger_secure_sdk_sys::*;
+use ledger_device_sdk::sys::*;
 
 pub fn try_option<A>(q: Option<A>) -> Result<A, CryptographyError> {
     q.ok_or(CryptographyError::NoneError)

--- a/src/eddsa.rs
+++ b/src/eddsa.rs
@@ -1,7 +1,7 @@
 use arrayvec::ArrayVec;
 use ledger_device_sdk::ecc::*;
 use ledger_device_sdk::io::SyscallError;
-use ledger_secure_sdk_sys::*;
+use ledger_device_sdk::sys::*;
 
 use crate::common::*;
 

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -3,7 +3,7 @@ use core::default::Default;
 use core::fmt;
 use core::fmt::Write;
 use core::ops::DerefMut;
-use ledger_secure_sdk_sys::*;
+use ledger_device_sdk::sys::*;
 use zeroize::{Zeroize, Zeroizing};
 
 pub trait Hasher {


### PR DESCRIPTION
This PR updates the Ledger Rust SDK dependencies: sys crate is now available through the sys feature.
PR should be merged when the new `ledger_device_sdk` crate ( version > 1.28) will be published on crates.io.